### PR TITLE
set nSamples_max to allow for conversion to single in filtering

### DIFF
--- a/planLoad.m
+++ b/planLoad.m
@@ -22,7 +22,8 @@ function [nLoad1, nSamples_load1, nSamples_last1] = planLoad(nBytes_file, P)
     end
 
     if ~isfield(P, 'MAX_LOAD_SEC') || isempty(P.MAX_LOAD_SEC)
-        nSamples_max = floor(P.MAX_BYTES_LOAD/(P.nChans*bytesPerSample_(P.dataType)));
+        bps = max(4, bytesPerSample_(P.dataType)); % conversion to single in filtering sets floor at 4
+        nSamples_max = floor(P.MAX_BYTES_LOAD/(P.nChans*bps);
     else
         nSamples_max = floor(P.sampleRateHz * P.MAX_LOAD_SEC);
     end


### PR DESCRIPTION
fix GPU OOM errors by loading only as many samples as the GPU can actually handle (either intrinsically in the case of double or converted to single, e.g., during filtering)