### PR TITLE
minor improvements

### DIFF
--- a/+jrclust/+import/kilosort.m
+++ b/+jrclust/+import/kilosort.m
@@ -72,9 +72,12 @@ end
 %%% try to detect the recording file
 % first check for a .meta file
 binfile = hCfg.rawRecordings{1};
+if isempty(hCfg.rawRecordings{1})
+    binfile = params.dat_path; % take ap.bin file location from .prm file by default
+end
 metafile = jrclust.utils.absPath(jrclust.utils.subsExt(binfile, '.meta'));
 if isempty(metafile)
-    dlgAns = questdlg('Do you have a .meta file?', 'Import', 'No');
+    dlgAns = questdlg('Do you have a .meta file?', 'Import', 'Yes','No','Cancel','Yes');
 
     switch dlgAns
         case 'Yes' % select .meta file

--- a/+jrclust/+import/kilosort.m
+++ b/+jrclust/+import/kilosort.m
@@ -27,13 +27,15 @@ cfgData.headerOffset = params.offset;
 cfgData.siteMap = channelMap;
 cfgData.siteLoc = channelPositions;
 cfgData.shankMap = ones(size(channelMap), 'like', channelMap); % this can change with a prm file
-cfgData.rawRecordings = {params.dat_path};
 
 % check for existence of .prm file. if exists use it as a template.
-[a,b,~] = fileparts(params.dat_path);
-prm_path = [a,filesep,b,'.prm'];
-if exist(prm_path,'file')
-    cfgData.template_file = prm_path;
+names = dir(loadPath);
+prm_candidate=contains({names.name},'.prm');
+if sum(prm_candidate)==1
+    prm_path = fullfile(loadPath,names(prm_candidate).name);
+    cfgData.template_file = prm_path;    
+else
+    warning('Could not find a .prm file in this directory to use as a template.');
 end
 hCfg = jrclust.Config(cfgData);
 
@@ -69,7 +71,7 @@ end
 
 %%% try to detect the recording file
 % first check for a .meta file
-binfile = params.dat_path;
+binfile = hCfg.rawRecordings{1};
 metafile = jrclust.utils.absPath(jrclust.utils.subsExt(binfile, '.meta'));
 if isempty(metafile)
     dlgAns = questdlg('Do you have a .meta file?', 'Import', 'No');

--- a/+jrclust/+utils/saveStruct.m
+++ b/+jrclust/+utils/saveStruct.m
@@ -12,8 +12,17 @@ function saveStruct(S, filename) %#ok<INUSL>
             catch
                 pause(.5);
             end
-
-            warning('Could not save: %s', filename);
+            if ispc 
+               userDir = char(java.lang.System.getProperty('user.home'));
+               filename_temp = [userDir,filesep,'tmp_jrclust.mat']; 
+               save(filename_temp, '-struct', 'S', '-v7.3', '-nocompression');
+               failed = system(sprintf('move "%s" "%s"',filename_temp,filename));
+               if failed
+                    warning('Could not save: %s', filename);
+               end  
+            else
+                warning('Could not save: %s', filename);                
+            end                
         end
     else
         for iRetry = 1:nRetries
@@ -23,8 +32,16 @@ function saveStruct(S, filename) %#ok<INUSL>
             catch
                 pause(.5);
             end
-
-            warning('Could not save: %s', filename);
+            if ispc 
+               userDir = char(java.lang.System.getProperty('user.home'));
+               filename_temp = [userDir,filesep,'tmp.mat']; 
+               save(filename_temp, '-struct', 'S', '-v7.3');
+               failed = system(sprintf('move "%s" "%s"',filename_temp,filename));
+               if failed
+                    warning('Could not save: %s', filename);
+               end  
+            else
+                warning
         end
     end
 end

--- a/@JRC/loadFiles.m
+++ b/@JRC/loadFiles.m
@@ -9,14 +9,34 @@ function loadFiles(obj)
         return;
     end
 
+    obj.hCfg.updateLog('loadRes', sprintf('Loading %s', obj.hCfg.resFile), 1, 0);
     try
-        obj.hCfg.updateLog('loadRes', sprintf('Loading %s', obj.hCfg.resFile), 1, 0);
         res_ = load(obj.hCfg.resFile);
-        obj.hCfg.updateLog('loadRes', sprintf('Finished loading %s', obj.hCfg.resFile), 0, 1);
     catch ME
-        warning('Failed to load %s: %s', ME.message);
-        return;
+        %% try to some hacks to get around windows path name length limitations, if that is the problem
+        if ispc
+            userDir = char(java.lang.System.getProperty('user.home'));
+            filename_temp = [userDir,filesep,'tmp_jrclust.mat']; 
+            failed = system(sprintf('copy "%s" "%s"',obj.hCfg.resFile,filename_temp));        
+            if ~failed
+                try
+                    res_ = load(filename_temp);
+                    delete(filename_temp);
+                catch
+                    warning('Failed to load %s: %s', ME.message);
+                    return;
+                end
+            else
+                warning('Failed to load %s: %s', ME.message);
+                return;            
+            end  
+        else
+            warning('Failed to load %s: %s', ME.message);
+            return;
+        end
     end
+    obj.hCfg.updateLog('loadRes', sprintf('Finished loading %s', obj.hCfg.resFile), 0, 1);
+
 
     if isfield(res_, 'spikeTimes')
         % load spikesRaw


### PR DESCRIPTION
Two improvements:
1. Windows has problems with very long path names. I added some workarounds to reduce crashing related to this. These workarounds only kick in on Windows if an error occurs during a save/load operation.
2. Minor change to the way kilosort import looks for the path name for the ap.bin file. It now prefers the path in the .prm file if one is provided, rather than the params.py file output by kilosort. The reasoning is that the params.py file only provides a local path, not a full path, requiring some error-prone reconstruction of the parent folder.